### PR TITLE
Add basic decoration custom resources, dragging and spawning for testing

### DIFF
--- a/Objects/Scenes/decoration.tscn
+++ b/Objects/Scenes/decoration.tscn
@@ -1,0 +1,25 @@
+[gd_scene load_steps=5 format=3 uid="uid://dxwwkypmyimqv"]
+
+[ext_resource type="Script" path="res://Objects/Scripts/decoration.gd" id="1_6dj7a"]
+[ext_resource type="Resource" uid="uid://hl6k4xercyag" path="res://Resources/Decorations/bauble.tres" id="2_woxl8"]
+
+[sub_resource type="PlaceholderTexture2D" id="PlaceholderTexture2D_qj83g"]
+size = Vector2(64, 64)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_dxf8o"]
+size = Vector2(64, 64)
+
+[node name="Decoration" type="StaticBody2D" groups=["clickable"]]
+input_pickable = true
+script = ExtResource("1_6dj7a")
+decoration_info = ExtResource("2_woxl8")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = SubResource("PlaceholderTexture2D_qj83g")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0.5, 0)
+shape = SubResource("RectangleShape2D_dxf8o")
+
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/Objects/Scripts/decoration.gd
+++ b/Objects/Scripts/decoration.gd
@@ -1,0 +1,49 @@
+class_name Decoration
+extends StaticBody2D
+
+@export var decoration_info: DecorationInfo
+
+@onready var sprite: Sprite2D = $Sprite2D
+
+var draggable: bool = false
+var dragging: bool = false
+var offset: Vector2
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	sprite.texture = decoration_info.texture
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	# No need to process if we're not dragging this decoration
+	if !draggable:
+		return
+	
+	# We're dragging and record the offset	
+	if Input.is_action_just_pressed("click"):
+		dragging = true
+		offset = get_global_mouse_position() - global_position
+		get_parent().move_child(self, -1)
+		
+	# Keep it moving
+	if dragging and Input.is_action_pressed("click"):
+		global_position = get_global_mouse_position() - offset
+	# and finished!
+	elif Input.is_action_just_released("click"):
+		dragging = false
+	
+
+func _on_mouse_entered() -> void:
+	draggable = true
+	scale = Vector2(1.05, 1.05)
+
+func _on_mouse_exited() -> void:
+	if !dragging:
+		draggable = false
+		scale = Vector2(1, 1)
+		
+# Current issues
+# - Overlapping Draggables can be selected at the same time
+#		Have an array of decorations that are on screen, 

--- a/Resources/Decorations/bauble.tres
+++ b/Resources/Decorations/bauble.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" script_class="DecorationInfo" load_steps=4 format=3 uid="uid://hl6k4xercyag"]
+
+[ext_resource type="Script" path="res://Util/Classes/decoration_info.gd" id="1_7t5qo"]
+
+[sub_resource type="Gradient" id="Gradient_bgxsi"]
+offsets = PackedFloat32Array(0, 0.519126, 1)
+colors = PackedColorArray(0.54902, 0, 0, 1, 0.184615, 0.184615, 0.184615, 1, 0.0901961, 0.588235, 0.160784, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_e4sql"]
+gradient = SubResource("Gradient_bgxsi")
+fill_to = Vector2(0.0598291, 0.0769231)
+repeat = 2
+
+[resource]
+script = ExtResource("1_7t5qo")
+name = "Bauble"
+texture = SubResource("GradientTexture2D_e4sql")

--- a/Resources/Decorations/candy_cane.tres
+++ b/Resources/Decorations/candy_cane.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" script_class="DecorationInfo" load_steps=4 format=3 uid="uid://b8pddfux6j1oy"]
+
+[ext_resource type="Script" path="res://Util/Classes/decoration_info.gd" id="1_qkqwq"]
+
+[sub_resource type="Gradient" id="Gradient_bgxsi"]
+offsets = PackedFloat32Array(0, 0.26776, 1)
+colors = PackedColorArray(0.54902, 0, 0, 1, 0.903598, 0.903598, 0.903598, 1, 1, 1, 1, 1)
+
+[sub_resource type="GradientTexture2D" id="GradientTexture2D_ox057"]
+gradient = SubResource("Gradient_bgxsi")
+fill_to = Vector2(0.0598291, 0.0769231)
+repeat = 2
+
+[resource]
+script = ExtResource("1_qkqwq")
+name = "Candy Cane"
+texture = SubResource("GradientTexture2D_ox057")

--- a/Util/Autoload/decoration_loader.gd
+++ b/Util/Autoload/decoration_loader.gd
@@ -1,0 +1,22 @@
+extends Node2D
+
+var decoration_scene: PackedScene = preload("res://Objects/Scenes/decoration.tscn")
+
+var decoration_info: Array[DecorationInfo]
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	var decoration_files: PackedStringArray = DirAccess.get_files_at("res://Resources/Decorations")
+	for decoration in decoration_files:
+		decoration_info.push_back(load("res://Resources/Decorations/" + decoration))
+
+func _physics_process(delta: float) -> void:
+	if Input.is_action_just_pressed("spawn_decoration"):
+		if(decoration_info.size):
+			spawn_decoration(decoration_info.pick_random())
+
+func spawn_decoration(info: DecorationInfo):
+	var spawned_decoration : Decoration = decoration_scene.instantiate()
+	spawned_decoration.decoration_info = info
+	get_tree().root.add_child(spawned_decoration)
+	spawned_decoration.global_position = get_global_mouse_position()

--- a/Util/Classes/decoration_info.gd
+++ b/Util/Classes/decoration_info.gd
@@ -1,0 +1,5 @@
+class_name DecorationInfo
+extends Resource
+
+@export var name : String
+@export var texture : Texture2D

--- a/assets/scenes/MainScene.tscn
+++ b/assets/scenes/MainScene.tscn
@@ -1,3 +1,13 @@
-[gd_scene format=3 uid="uid://bijwkbh0wth4j"]
+[gd_scene load_steps=3 format=3 uid="uid://bijwkbh0wth4j"]
+
+[ext_resource type="PackedScene" uid="uid://dxwwkypmyimqv" path="res://Objects/Scenes/decoration.tscn" id="1_cl8wi"]
+[ext_resource type="Resource" uid="uid://b8pddfux6j1oy" path="res://Resources/Decorations/candy_cane.tres" id="2_yihbi"]
 
 [node name="Game" type="Node2D"]
+
+[node name="Decoration" parent="." instance=ExtResource("1_cl8wi")]
+position = Vector2(325, 141)
+
+[node name="Decoration2" parent="." instance=ExtResource("1_cl8wi")]
+position = Vector2(93, 146)
+decoration_info = ExtResource("2_yihbi")

--- a/project.godot
+++ b/project.godot
@@ -18,12 +18,46 @@ config/icon="res://icon.svg"
 [autoload]
 
 Main="*res://scripts/globals/Main.gd"
+DecorationLoader="*res://Util/Autoload/decoration_loader.gd"
 
 [display]
 
-window/size/viewport_width=480
-window/size/viewport_height=270
+window/size/viewport_width=960
+window/size/viewport_height=540
 window/stretch/mode="viewport"
+
+[editor]
+
+version_control/plugin_name="GitPlugin"
+version_control/autoload_on_startup=true
+
+[file_customization]
+
+folder_colors={
+"res://Art/": "purple",
+"res://Objects/": "orange",
+"res://Resources/": "teal",
+"res://Scenes/": "green",
+"res://UI/": "pink",
+"res://Util/": "gray"
+}
+
+[global_group]
+
+clickable="All clickable elements"
+
+[input]
+
+click={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":1,"position":Vector2(94, 0),"global_position":Vector2(103, 46),"factor":1.0,"button_index":1,"canceled":false,"pressed":true,"double_click":false,"script":null)
+]
+}
+spawn_decoration={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
+]
+}
 
 [rendering]
 


### PR DESCRIPTION
This PR brings in some basic dragging functionality to the decorations on screen.

The custom resources (Resources / Decorations / bauble + candy_cane) are how we cna add new decorations to the game without having to fiddle with too much code.
Left is candy_cane, right is bauble.
![image](https://github.com/user-attachments/assets/74105b85-a699-4331-9679-969c634fa580)

Randomly spawn decorations by pressing [E]!

